### PR TITLE
Add a check to handle input text with fewer than 25 words.

### DIFF
--- a/02-go-forth/tf-02.py
+++ b/02-go-forth/tf-02.py
@@ -101,7 +101,9 @@ read_file(); filter_chars(); scan(); remove_stop_words()
 frequencies(); sort()
 
 stack.append(0)
-while stack[-1] < 25:
+# Check stack length against 1, because after we process
+# the last word there will be one item left
+while stack[-1] < 25 and len(stack) > 1:
     heap['i'] = stack.pop()
     (w, f) = stack.pop(); print w, ' - ', f
     stack.append(heap['i']); stack.append(1)


### PR DESCRIPTION
The final blog in the main program throws an error when the stack is empty.  To avoid this, add a check to the while loop for the size of the stack.  Stop the loop when the stack has 1 element remaining (the last element will be the count from the last iteration of the loop, not a word).
