### PR TITLE
Clojure Code Golf

### DIFF
--- a/06-code-golf/tf-06.clj
+++ b/06-code-golf/tf-06.clj
@@ -6,4 +6,4 @@
                 (remove 
                   #(contains? (set (.split (slurp "../stop_words.txt") ",")) %)
                   (re-seq #"[a-z]{2,}" (.toLowerCase (slurp (first *command-line-args*))))))))]
-  (printf "%s - %d\n" (first c) (nth c 1)))
+  (println (first c) "-" (nth c 1)))


### PR DESCRIPTION
I offer a Clojure code golf solution with 201 non-space characters, not including the exec statement. This solution leverages java interop to avoid requiring clojure.string, and uses set/contains? to remove stop-word matches.

One possibility for improvement (per the constraints of the exercise) is to condense the code into fewer lines. However, I wonder if squishing would take away from clarity. 
