### PR TITLE
Fix word_id in 25-persistent-tables

### DIFF
--- a/25-persistent-tables/tf-25.py
+++ b/25-persistent-tables/tf-25.py
@@ -37,9 +37,7 @@ def load_file_into_database(path_to_file, connection):
     # Add the words to the database
     c.execute("SELECT MAX(id) FROM words")
     row = c.fetchone()
-    word_id = row[0]
-    if word_id == None:
-        word_id = 0
+    word_id = row[0] + 1 if row[0] != None else 0
     for w in words:
         c.execute("INSERT INTO words VALUES (?, ?, ?)", (word_id, doc_id, w))
         # Add the characters to the database


### PR DESCRIPTION
"MAX(id) FROM words" was used as word_id for INSERT of next word,
which will result in duplicate word ids.

(Of course, in its current form, the application always runs the code against
an empty database, so the error is not triggered.)