### PR TITLE
Fix the initial character missing problem for exercise 40

### DIFF
--- a/40-recurrent/tf-40.py
+++ b/40-recurrent/tf-40.py
@@ -82,7 +82,7 @@ input("Network has been trained. Press <Enter> to run program.")
 with open(sys.argv[1]) as f:
     for line in f:
         if line.isspace(): continue
-        batch = prepare_for_rnn(encode_one_hot(line))
+        batch = prepare_for_rnn(encode_one_hot(" " + line + " "))
         preds = model.predict(batch)
         normal = decode_one_hot(preds)
         print(normal)


### PR DESCRIPTION
The output lines of the example program always start with the initial character missing. Just add two space characters at each end of the line should fix this bug.